### PR TITLE
Add claude-ball

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ under the "programming" rubric. I have now excluded a number of titles such as
 * [Battlecode](https://www.battlecode.org/)
 * [Blockly](https://blockly.games/)
 * [Carnival](https://codepen.io/una/pen/NxZaNr)
+* [claude-ball](https://claude-ball.fly.dev) - Coach a 2D soccer team by describing the tactics in plain English; your AI coding agent writes the bot's brain in TypeScript (a CLAUDE.md keeps it to coding, never strategy), and you climb a deterministic ladder against built-in and community bots. Open source.
 * [CodeCraft](http://www.codecraftgame.org/)
 * [CSS Diner](http://flukeout.github.io/)
 * [CTF Learn](https://ctflearn.com/)


### PR DESCRIPTION
Hey, thanks for the list! Adding **claude-ball**, an open-source programming game that fits the browser/server-based section.

You coach a 2D soccer team, but you only do the tactics, not the typing: you describe how the team should play in plain English and your AI coding agent writes the bot's brain in TypeScript. A `CLAUDE.md` keeps the agent to coding and out of strategy. Matches are deterministic, and you submit your bot to a live ladder against built-in bots and everyone else's.

- Play / watch: https://claude-ball.fly.dev
- Code: https://github.com/amitayk/claude-ball