### PR TITLE
Add CodeCityApp to coding resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ under the "programming" rubric. I have now excluded a number of titles such as
 * [Code.org](https://code.org/)
 * [CodeCombat](https://codecombat.com/)
 <!-- Codefinity? -->
+* [CodeCityApp](https://codecityapp.com) - Solve coding challenges gated by passing tests to grow a persistent city, with XP, streaks and a built-in AI mentor. Free tier available.
 * [Codingame](https://www.codingame.com/)
 * [corewars8086_js](https://shooshx.github.io/corewars8086_js/)
 * [Cube Composer](https://david-peter.de/cube-composer/)


### PR DESCRIPTION
Adds CodeCityApp (https://codecityapp.com) to Recent Games, Browser- or Server-Based, placed alphabetically between CodeCombat and Codingame.

On the gamified criterion: it has XP, levels, streaks, and a persistent city that grows as challenges are completed, so it carries the trappings of a traditional game rather than being a bare challenge site. Challenges are gated by passing tests and a built-in AI mentor gives contextual help. Browser-based and readily playable with a free tier.