### PR TITLE
Add digiwleea (browser-based)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ under the "programming" rubric. I have now excluded a number of titles such as
 * [CSS Diner](http://flukeout.github.io/)
 * [CTF Learn](https://ctflearn.com/)
 * [CheckiO](https://checkio.org/)
+* [digiwleea](https://digiwleea.wleeaf.dev/) - Gamified logic design: build gates from transistors up to a working 8-bit CPU in the browser.
 * [CODE4WIN](https://code4win.com/)
 * [Code Games](http://codegames.io)
 * [Code Monkey](https://www.codemonkey.com/)


### PR DESCRIPTION
Adds digiwleea to **Recent Games, Browser- or Server-Based** (alphabetically, after CheckiO): a gamified path from single transistors to a working 8-bit CPU with levels, XP, and a daily puzzle, in the same family as NandGame which is already listed. Free to play in the browser, no account needed.

Disclosure: I'm the author.